### PR TITLE
Enable super admin workspace privileges

### DIFF
--- a/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
@@ -56,6 +56,7 @@ import { DataSourceModule } from 'src/engine/metadata-modules/data-source/data-s
 import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
 import { PermissionsModule } from 'src/engine/metadata-modules/permissions/permissions.module';
 import { UserRoleModule } from 'src/engine/metadata-modules/user-role/user-role.module';
+import { RoleEntity } from 'src/engine/metadata-modules/role/role.entity';
 import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { WorkspaceManagerModule } from 'src/engine/workspace-manager/workspace-manager.module';
 import { ConnectedAccountModule } from 'src/modules/connected-account/connected-account.module';
@@ -85,6 +86,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
         WorkspaceSSOIdentityProvider,
         KeyValuePair,
         UserWorkspace,
+        RoleEntity,
       ],
       'core',
     ),


### PR DESCRIPTION
## Summary
- let AccessTokenService assign admin role when creating userWorkspace for super admin
- register RoleEntity and UserRoleService in AccessTokenService
- expose RoleEntity to AuthModule so AccessTokenService can query admin role

## Testing
- `yarn nx run-many -t lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6871cf734974832a9b53149377b30293