### PR TITLE
Add LocalCalendarEvent entity

### DIFF
--- a/packages/twenty-front/src/modules/object-metadata/types/CoreObjectNamePlural.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/CoreObjectNamePlural.ts
@@ -6,6 +6,7 @@ export enum CoreObjectNamePlural {
   Blocklist = 'blocklists',
   CalendarChannel = 'calendarChannels',
   CalendarEvent = 'calendarEvents',
+  LocalCalendarEvent = 'localCalendarEvents',
   Comment = 'comments',
   Company = 'companies',
   ConnectedAccount = 'connectedAccounts',

--- a/packages/twenty-front/src/modules/object-metadata/types/CoreObjectNameSingular.ts
+++ b/packages/twenty-front/src/modules/object-metadata/types/CoreObjectNameSingular.ts
@@ -6,6 +6,7 @@ export enum CoreObjectNameSingular {
   Blocklist = 'blocklist',
   CalendarChannel = 'calendarChannel',
   CalendarEvent = 'calendarEvent',
+  LocalCalendarEvent = 'localCalendarEvent',
   Comment = 'comment',
   Company = 'company',
   ConnectedAccount = 'connectedAccount',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -111,6 +111,19 @@ export const CALENDAR_EVENT_STANDARD_FIELD_IDS = {
   calendarEventParticipants: '20202020-e07e-4ccb-88f5-6f3d00458eec',
 };
 
+export const LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS = {
+  title: '20202020-eef1-4fc6-8d9f-a36fd3c1e0b1',
+  description: '20202020-7d48-42b2-b3d2-1a9ecc98d079',
+  startsAt: '20202020-8aaf-4a32-8dd9-56cb9ed6c8b6',
+  endsAt: '20202020-2a4e-4e4e-9eca-6e8deb7d9d16',
+  location: '20202020-9aad-4ab7-bafd-0da677343b7a',
+  isFullDay: '20202020-a8c8-42c7-9e4a-3cb764560aac',
+  isCanceled: '20202020-8754-4182-8bea-fa9ef7d70b4b',
+  person: '20202020-1d85-4e37-9757-e219ffa2c755',
+  company: '20202020-bcdd-4ec5-b313-fc6dc7622fe7',
+  creator: '20202020-f3c1-4d95-8ba3-81d2ce60cf8b',
+};
+
 // TODO: check if this can be deleted
 export const COMMENT_STANDARD_FIELD_IDS = {
   body: '20202020-d5eb-49d2-b3e0-1ed04145ebb7',
@@ -559,6 +572,7 @@ export const STANDARD_OBJECT_FIELD_IDS = {
   calendarChannel: CALENDAR_CHANNEL_STANDARD_FIELD_IDS,
   calendarEventParticipant: CALENDAR_EVENT_PARTICIPANT_STANDARD_FIELD_IDS,
   calendarEvent: CALENDAR_EVENT_STANDARD_FIELD_IDS,
+  localCalendarEvent: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS,
   comment: COMMENT_STANDARD_FIELD_IDS,
   company: COMPANY_STANDARD_FIELD_IDS,
   connectedAccount: CONNECTED_ACCOUNT_STANDARD_FIELD_IDS,

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons.ts
@@ -9,6 +9,7 @@ export const STANDARD_OBJECT_ICONS = {
   calendarChannel: 'IconCalendar',
   calendarEventParticipant: 'IconCalendar',
   calendarEvent: 'IconCalendar',
+  localCalendarEvent: 'IconCalendar',
   comment: 'IconMessageCircle',
   company: 'IconBuildingSkyscraper',
   connectedAccount: 'IconAt',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids.ts
@@ -17,6 +17,7 @@ export const STANDARD_OBJECT_IDS = {
   calendarChannel: '20202020-e8f2-40e1-a39c-c0e0039c5034',
   calendarEventParticipant: '20202020-a1c3-47a6-9732-27e5b1e8436d',
   calendarEvent: '20202020-8f1d-4eef-9f85-0d1965e27221',
+  localCalendarEvent: '20202020-3b6f-4ec2-a1c0-08a296b271d8',
   comment: '20202020-435f-4de9-89b5-97e32233bf5f',
   company: '20202020-b374-4779-a561-80086cb2e17f',
   connectedAccount: '20202020-977e-46b2-890b-c3002ddfd5c5',

--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/standard-objects/index.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/standard-objects/index.ts
@@ -5,6 +5,7 @@ import { CalendarChannelEventAssociationWorkspaceEntity } from 'src/modules/cale
 import { CalendarChannelWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-channel.workspace-entity';
 import { CalendarEventParticipantWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event-participant.workspace-entity';
 import { CalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/calendar-event.workspace-entity';
+import { LocalCalendarEventWorkspaceEntity } from 'src/modules/calendar/common/standard-objects/local-calendar-event.workspace-entity';
 import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
 import { ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
 import { FavoriteFolderWorkspaceEntity } from 'src/modules/favorite-folder/standard-objects/favorite-folder.workspace-entity';
@@ -40,6 +41,7 @@ export const standardObjectMetadataDefinitions = [
   AttachmentWorkspaceEntity,
   BlocklistWorkspaceEntity,
   CalendarEventWorkspaceEntity,
+  LocalCalendarEventWorkspaceEntity,
   CalendarChannelWorkspaceEntity,
   CalendarChannelEventAssociationWorkspaceEntity,
   CalendarEventParticipantWorkspaceEntity,

--- a/packages/twenty-server/src/modules/calendar/common/standard-objects/local-calendar-event.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/calendar/common/standard-objects/local-calendar-event.workspace-entity.ts
@@ -1,0 +1,135 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import { LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids';
+import { STANDARD_OBJECT_ICONS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-icons';
+import { STANDARD_OBJECT_IDS } from 'src/engine/workspace-manager/workspace-sync-metadata/constants/standard-object-ids';
+import { CompanyWorkspaceEntity } from 'src/modules/company/standard-objects/company.workspace-entity';
+import { PersonWorkspaceEntity } from 'src/modules/person/standard-objects/person.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+@WorkspaceEntity({
+  standardId: STANDARD_OBJECT_IDS.localCalendarEvent,
+  namePlural: 'localCalendarEvents',
+  labelSingular: msg`Local calendar event`,
+  labelPlural: msg`Local calendar events`,
+  description: msg`Local calendar events`,
+  icon: STANDARD_OBJECT_ICONS.localCalendarEvent,
+  labelIdentifierStandardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.title,
+})
+export class LocalCalendarEventWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.title,
+    type: FieldMetadataType.TEXT,
+    label: msg`Title`,
+    description: msg`Title`,
+    icon: 'IconH1',
+  })
+  title: string;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.description,
+    type: FieldMetadataType.TEXT,
+    label: msg`Description`,
+    description: msg`Description`,
+    icon: 'IconFileDescription',
+  })
+  @WorkspaceIsNullable()
+  description: string | null;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.startsAt,
+    type: FieldMetadataType.DATE_TIME,
+    label: msg`Start Date`,
+    description: msg`Start Date`,
+    icon: 'IconCalendarClock',
+  })
+  startsAt: string;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.endsAt,
+    type: FieldMetadataType.DATE_TIME,
+    label: msg`End Date`,
+    description: msg`End Date`,
+    icon: 'IconCalendarClock',
+  })
+  endsAt: string;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.location,
+    type: FieldMetadataType.TEXT,
+    label: msg`Location`,
+    description: msg`Location`,
+    icon: 'IconMapPin',
+  })
+  @WorkspaceIsNullable()
+  location: string | null;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.isFullDay,
+    type: FieldMetadataType.BOOLEAN,
+    label: msg`Is Full Day`,
+    description: msg`Is Full Day`,
+    icon: 'IconHours24',
+    defaultValue: false,
+  })
+  isFullDay: boolean;
+
+  @WorkspaceField({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.isCanceled,
+    type: FieldMetadataType.BOOLEAN,
+    label: msg`Is canceled`,
+    description: msg`Is canceled`,
+    icon: 'IconCalendarCancel',
+    defaultValue: false,
+  })
+  isCanceled: boolean;
+
+  @WorkspaceRelation({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.person,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Person`,
+    description: msg`Person`,
+    icon: 'IconUser',
+    inverseSideTarget: () => PersonWorkspaceEntity,
+    inverseSideFieldKey: 'localCalendarEvents',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  person: Relation<PersonWorkspaceEntity> | null;
+
+  @WorkspaceRelation({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.company,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Company`,
+    description: msg`Company`,
+    icon: 'IconBuildingSkyscraper',
+    inverseSideTarget: () => CompanyWorkspaceEntity,
+    inverseSideFieldKey: 'localCalendarEvents',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  company: Relation<CompanyWorkspaceEntity> | null;
+
+  @WorkspaceRelation({
+    standardId: LOCAL_CALENDAR_EVENT_STANDARD_FIELD_IDS.creator,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Creator`,
+    description: msg`Creator`,
+    icon: 'IconUser',
+    inverseSideTarget: () => WorkspaceMemberWorkspaceEntity,
+    inverseSideFieldKey: 'localCalendarEvents',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  creator: Relation<WorkspaceMemberWorkspaceEntity> | null;
+}


### PR DESCRIPTION
## Summary
- add `LocalCalendarEventWorkspaceEntity` for local CRM calendar
- register standard field/ID metadata and icon
- expose the entity in standard object exports
- extend CoreObjectName enums with LocalCalendarEvent

## Testing
- `npx nx lint twenty-server` *(fails: needs interactive package install)*
- `npx nx run twenty-server:command workspace:sync-metadata -f` *(fails: needs interactive package install)*

------
https://chatgpt.com/codex/tasks/task_e_6878d6761774832a8da3dc26dec454ce