### PR TITLE
Add hook and button for creating local calendar events

### DIFF
--- a/packages/twenty-front/src/modules/activities/calendar/components/LocalCalendarNewEventButton.tsx
+++ b/packages/twenty-front/src/modules/activities/calendar/components/LocalCalendarNewEventButton.tsx
@@ -1,0 +1,39 @@
+import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
+import { useCreateNewLocalCalendarEvent } from '@/activities/calendar/hooks/useCreateNewLocalCalendarEvent';
+import { useObjectMetadataItem } from '@/object-metadata/hooks/useObjectMetadataItem';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { useObjectPermissionsForObject } from '@/object-record/hooks/useObjectPermissionsForObject';
+import { IconPlus } from 'twenty-ui/display';
+import { Button, ButtonProps } from 'twenty-ui/input';
+
+export const LocalCalendarNewEventButton = ({
+  targetableObject,
+  ...buttonProps
+}: {
+  targetableObject: ActivityTargetableObject;
+} & Omit<ButtonProps, 'onClick' | 'Icon' | 'title'>) => {
+  const { objectMetadataItem } = useObjectMetadataItem({
+    objectNameSingular: CoreObjectNameSingular.LocalCalendarEvent,
+  });
+
+  const objectPermissions = useObjectPermissionsForObject(objectMetadataItem.id);
+
+  const { createNewLocalCalendarEvent } = useCreateNewLocalCalendarEvent();
+
+  if (!objectPermissions.canCreateObjectRecords) {
+    return null;
+  }
+
+  return (
+    <Button
+      Icon={IconPlus}
+      title="New event"
+      variant="secondary"
+      size="small"
+      onClick={() =>
+        createNewLocalCalendarEvent({ targetableObject })
+      }
+      {...buttonProps}
+    />
+  );
+};

--- a/packages/twenty-front/src/modules/activities/calendar/hooks/useCreateNewLocalCalendarEvent.ts
+++ b/packages/twenty-front/src/modules/activities/calendar/hooks/useCreateNewLocalCalendarEvent.ts
@@ -1,0 +1,54 @@
+import { useRecoilCallback } from 'recoil';
+import { useOpenRecordInCommandMenu } from '@/command-menu/hooks/useOpenRecordInCommandMenu';
+import { CoreObjectNameSingular } from '@/object-metadata/types/CoreObjectNameSingular';
+import { useCreateOneRecord } from '@/object-record/hooks/useCreateOneRecord';
+import { ObjectRecord } from '@/object-record/types/ObjectRecord';
+import { ActivityTargetableObject } from '@/activities/types/ActivityTargetableEntity';
+import { v4 } from 'uuid';
+
+export const useCreateNewLocalCalendarEvent = () => {
+  const { createOneRecord } = useCreateOneRecord({
+    objectNameSingular: CoreObjectNameSingular.LocalCalendarEvent,
+    shouldMatchRootQueryFilter: true,
+  });
+
+  const { openRecordInCommandMenu } = useOpenRecordInCommandMenu();
+
+  const createNewLocalCalendarEvent = useRecoilCallback(
+    () =>
+      async ({
+        targetableObject,
+        recordInput,
+      }: {
+        targetableObject: ActivityTargetableObject;
+        recordInput?: Partial<ObjectRecord>;
+      }) => {
+        const recordId = v4();
+
+        const relationFieldName =
+          targetableObject.targetObjectNameSingular === 'person'
+            ? 'personId'
+            : 'companyId';
+
+        await createOneRecord({
+          id: recordId,
+          title: 'Untitled Event',
+          startsAt: new Date().toISOString(),
+          endsAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          isFullDay: false,
+          isCanceled: false,
+          [relationFieldName]: targetableObject.id,
+          ...recordInput,
+        });
+
+        openRecordInCommandMenu({
+          recordId,
+          objectNameSingular: CoreObjectNameSingular.LocalCalendarEvent,
+          isNewRecord: true,
+        });
+      },
+    [createOneRecord, openRecordInCommandMenu],
+  );
+
+  return { createNewLocalCalendarEvent };
+};


### PR DESCRIPTION
## Summary
- add `useCreateNewLocalCalendarEvent` hook for generating local events
- add `LocalCalendarNewEventButton` component that uses the hook

## Testing
- `yarn nx test twenty-front`

------
https://chatgpt.com/codex/tasks/task_e_6878e3d704ec832a8b32a1f1496b69c7