### PR TITLE
Add sample custom objects for seeding

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/deal-custom-field-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/deal-custom-field-seeds.constant.ts
@@ -1,0 +1,86 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { FieldMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/field-metadata-seed.type';
+
+export const DEAL_CUSTOM_FIELD_SEEDS: FieldMetadataSeed[] = [
+  { type: FieldMetadataType.TEXT, label: 'Deal Name', name: 'dealName' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Deal Stage',
+    name: 'dealStage',
+    options: [
+      {
+        label: 'Prospecting',
+        value: 'PROSPECTING',
+        position: 0,
+        color: 'blue',
+      },
+      { label: 'Won', value: 'WON', position: 1, color: 'green' },
+      { label: 'Lost', value: 'LOST', position: 2, color: 'red' },
+    ],
+  },
+  { type: FieldMetadataType.CURRENCY, label: 'Amount', name: 'amount' },
+  { type: FieldMetadataType.NUMBER, label: 'Probability', name: 'probability' },
+  { type: FieldMetadataType.DATE, label: 'Close Date', name: 'closeDate' },
+  { type: FieldMetadataType.FULL_NAME, label: 'Deal Owner', name: 'dealOwner' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Linked Contact',
+    name: 'linkedContact',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Linked Account',
+    name: 'linkedAccount',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Linked Campaign',
+    name: 'linkedCampaign',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Source',
+    name: 'source',
+    options: [
+      { label: 'Website', value: 'WEBSITE', position: 0, color: 'blue' },
+      { label: 'Referral', value: 'REFERRAL', position: 1, color: 'green' },
+    ],
+  },
+  { type: FieldMetadataType.FULL_NAME, label: 'Create By', name: 'createBy' },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Created Date',
+    name: 'createdDate',
+  },
+  {
+    type: FieldMetadataType.FULL_NAME,
+    label: 'Modified By',
+    name: 'modifiedBy',
+  },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Modified Date',
+    name: 'modifiedDate',
+  },
+  {
+    type: FieldMetadataType.MULTI_SELECT,
+    label: 'Products',
+    name: 'products',
+    options: [
+      { label: 'Product A', value: 'PRODUCT_A', position: 0, color: 'blue' },
+      { label: 'Product B', value: 'PRODUCT_B', position: 1, color: 'green' },
+    ],
+  },
+  { type: FieldMetadataType.TEXT, label: 'Notes', name: 'notes' },
+  { type: FieldMetadataType.TEXT, label: 'Attachments', name: 'attachments' },
+  {
+    type: FieldMetadataType.MULTI_SELECT,
+    label: 'Tags',
+    name: 'tags',
+    options: [
+      { label: 'Important', value: 'IMPORTANT', position: 0, color: 'red' },
+      { label: 'Follow Up', value: 'FOLLOW_UP', position: 1, color: 'blue' },
+    ],
+  },
+];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/lead-custom-field-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/lead-custom-field-seeds.constant.ts
@@ -1,0 +1,144 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { FieldMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/field-metadata-seed.type';
+
+export const LEAD_CUSTOM_FIELD_SEEDS: FieldMetadataSeed[] = [
+  { type: FieldMetadataType.FULL_NAME, label: 'Full Name', name: 'fullName' },
+  { type: FieldMetadataType.PHONES, label: 'Mobile', name: 'mobile' },
+  { type: FieldMetadataType.EMAILS, label: 'Email', name: 'email' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Gender',
+    name: 'gender',
+    options: [
+      { label: 'Male', value: 'MALE', position: 0, color: 'blue' },
+      { label: 'Female', value: 'FEMALE', position: 1, color: 'pink' },
+      { label: 'Other', value: 'OTHER', position: 2, color: 'gray' },
+    ],
+  },
+  { type: FieldMetadataType.DATE, label: 'Birthdate', name: 'birthdate' },
+  { type: FieldMetadataType.ADDRESS, label: 'Address', name: 'address' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Data Source',
+    name: 'dataSource',
+    options: [
+      { label: 'Online', value: 'ONLINE', position: 0, color: 'blue' },
+      { label: 'Referral', value: 'REFERRAL', position: 1, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Campaign',
+    name: 'campaign',
+    options: [
+      { label: 'Campaign A', value: 'CAMPAIGN_A', position: 0, color: 'blue' },
+      { label: 'Campaign B', value: 'CAMPAIGN_B', position: 1, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Date Create',
+    name: 'dateCreate',
+  },
+  { type: FieldMetadataType.SELECT, label: 'Assigned To', name: 'assignedTo' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Lead Status',
+    name: 'leadStatus',
+    options: [
+      { label: 'New', value: 'NEW', position: 0, color: 'blue' },
+      { label: 'Qualified', value: 'QUALIFIED', position: 1, color: 'green' },
+      { label: 'Lost', value: 'LOST', position: 2, color: 'red' },
+    ],
+  },
+  { type: FieldMetadataType.RATING, label: 'Lead Score', name: 'leadScore' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Interest Level',
+    name: 'interestLevel',
+    options: [
+      { label: 'High', value: 'HIGH', position: 0, color: 'green' },
+      { label: 'Medium', value: 'MEDIUM', position: 1, color: 'yellow' },
+      { label: 'Low', value: 'LOW', position: 2, color: 'red' },
+    ],
+  },
+  {
+    type: FieldMetadataType.TEXT,
+    label: 'Learning Objective',
+    name: 'learningObjective',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Current Level',
+    name: 'currentLevel',
+    options: [
+      { label: 'Beginner', value: 'BEGINNER', position: 0, color: 'blue' },
+      {
+        label: 'Intermediate',
+        value: 'INTERMEDIATE',
+        position: 1,
+        color: 'yellow',
+      },
+      { label: 'Advanced', value: 'ADVANCED', position: 2, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Interested Program',
+    name: 'interestedProgram',
+    options: [
+      { label: 'Program A', value: 'PROGRAM_A', position: 0, color: 'blue' },
+      { label: 'Program B', value: 'PROGRAM_B', position: 1, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Preferred Learning Format',
+    name: 'preferredLearningFormat',
+    options: [
+      { label: 'Online', value: 'ONLINE', position: 0, color: 'blue' },
+      { label: 'Offline', value: 'OFFLINE', position: 1, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.TEXT,
+    label: 'Advisor Notes',
+    name: 'advisorNotes',
+  },
+  {
+    type: FieldMetadataType.MULTI_SELECT,
+    label: 'Tags',
+    name: 'tags',
+    options: [
+      { label: 'Hot', value: 'HOT', position: 0, color: 'red' },
+      { label: 'Cold', value: 'COLD', position: 1, color: 'blue' },
+    ],
+  },
+  {
+    type: FieldMetadataType.BOOLEAN,
+    label: 'Center Visit Status',
+    name: 'centerVisitStatus',
+  },
+  {
+    type: FieldMetadataType.DATE,
+    label: 'Last Visit Date',
+    name: 'lastVisitDate',
+  },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Appointment',
+    name: 'appointment',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Linked Student',
+    name: 'linkedStudent',
+  },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Deal Created',
+    name: 'dealCreated',
+  },
+  { type: FieldMetadataType.FULL_NAME, label: 'Create By', name: 'createBy' },
+];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/student-custom-field-seeds.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/student-custom-field-seeds.constant.ts
@@ -1,0 +1,149 @@
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { FieldMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/field-metadata-seed.type';
+
+export const STUDENT_CUSTOM_FIELD_SEEDS: FieldMetadataSeed[] = [
+  { type: FieldMetadataType.TEXT, label: 'Student ID', name: 'studentId' },
+  { type: FieldMetadataType.FULL_NAME, label: 'Full Name', name: 'fullName' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Gender',
+    name: 'gender',
+    options: [
+      { label: 'Male', value: 'MALE', position: 0, color: 'blue' },
+      { label: 'Female', value: 'FEMALE', position: 1, color: 'pink' },
+      { label: 'Other', value: 'OTHER', position: 2, color: 'gray' },
+    ],
+  },
+  { type: FieldMetadataType.DATE, label: 'Birthdate', name: 'birthdate' },
+  {
+    type: FieldMetadataType.PHONES,
+    label: 'Phone Number',
+    name: 'phoneNumber',
+  },
+  { type: FieldMetadataType.EMAILS, label: 'Email', name: 'email' },
+  { type: FieldMetadataType.ADDRESS, label: 'Address', name: 'address' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Current Level',
+    name: 'currentLevel',
+    options: [
+      { label: 'Beginner', value: 'BEGINNER', position: 0, color: 'blue' },
+      {
+        label: 'Intermediate',
+        value: 'INTERMEDIATE',
+        position: 1,
+        color: 'yellow',
+      },
+      { label: 'Advanced', value: 'ADVANCED', position: 2, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.DATE,
+    label: 'First Enrollment Date',
+    name: 'firstEnrollmentDate',
+  },
+  {
+    type: FieldMetadataType.TEXT,
+    label: 'Learning Goals',
+    name: 'learningGoals',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Learning Mode',
+    name: 'learningMode',
+    options: [
+      { label: 'Online', value: 'ONLINE', position: 0, color: 'blue' },
+      { label: 'Offline', value: 'OFFLINE', position: 1, color: 'green' },
+    ],
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Learning Status',
+    name: 'learningStatus',
+    options: [
+      { label: 'Active', value: 'ACTIVE', position: 0, color: 'green' },
+      { label: 'Paused', value: 'PAUSED', position: 1, color: 'yellow' },
+      { label: 'Completed', value: 'COMPLETED', position: 2, color: 'blue' },
+    ],
+  },
+  { type: FieldMetadataType.TEXT, label: 'Description', name: 'description' },
+  {
+    type: FieldMetadataType.MULTI_SELECT,
+    label: 'Tags',
+    name: 'tags',
+    options: [
+      { label: 'VIP', value: 'VIP', position: 0, color: 'red' },
+      {
+        label: 'Scholarship',
+        value: 'SCHOLARSHIP',
+        position: 1,
+        color: 'blue',
+      },
+    ],
+  },
+  {
+    type: FieldMetadataType.TEXT,
+    label: 'Parent Full Name',
+    name: 'parentFullName',
+  },
+  {
+    type: FieldMetadataType.PHONES,
+    label: 'Parent Phone Number',
+    name: 'parentPhoneNumber',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Enrolled Program',
+    name: 'enrolledProgram',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Enrolled Class',
+    name: 'enrolledClass',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Assigned Teacher',
+    name: 'assignedTeacher',
+  },
+  {
+    type: FieldMetadataType.DATE,
+    label: 'Class Enrollment Date',
+    name: 'classEnrollmentDate',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Tuition Order',
+    name: 'tuitionOrder',
+  },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Payment History',
+    name: 'paymentHistory',
+  },
+  { type: FieldMetadataType.SELECT, label: 'Gradebook', name: 'gradebook' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Attendance Record',
+    name: 'attendanceRecord',
+  },
+  { type: FieldMetadataType.SELECT, label: 'Appointment', name: 'appointment' },
+  {
+    type: FieldMetadataType.SELECT,
+    label: 'Converted From Lead',
+    name: 'convertedFromLead',
+  },
+  { type: FieldMetadataType.SELECT, label: 'Người tạo', name: 'creator' },
+  { type: FieldMetadataType.DATE_TIME, label: 'Ngày tạo', name: 'dateCreated' },
+  {
+    type: FieldMetadataType.DATE_TIME,
+    label: 'Ngày cập nhật gần nhất',
+    name: 'lastUpdated',
+  },
+  {
+    type: FieldMetadataType.BOOLEAN,
+    label: 'Trạng thái hoạt động',
+    name: 'isActive',
+  },
+];

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/deal-custom-object-seed.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/deal-custom-object-seed.constant.ts
@@ -1,0 +1,9 @@
+import { ObjectMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/object-metadata-seed.type';
+
+export const DEAL_CUSTOM_OBJECT_SEED: ObjectMetadataSeed = {
+  labelPlural: 'Deals',
+  labelSingular: 'Deal',
+  namePlural: 'deals',
+  nameSingular: 'deal',
+  icon: 'IconBriefcase',
+};

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/lead-custom-object-seed.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/lead-custom-object-seed.constant.ts
@@ -1,0 +1,9 @@
+import { ObjectMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/object-metadata-seed.type';
+
+export const LEAD_CUSTOM_OBJECT_SEED: ObjectMetadataSeed = {
+  labelPlural: 'Leads',
+  labelSingular: 'Lead',
+  namePlural: 'leads',
+  nameSingular: 'lead',
+  icon: 'IconUserPlus',
+};

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/student-custom-object-seed.constant.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/student-custom-object-seed.constant.ts
@@ -1,0 +1,9 @@
+import { ObjectMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/object-metadata-seed.type';
+
+export const STUDENT_CUSTOM_OBJECT_SEED: ObjectMetadataSeed = {
+  labelPlural: 'Students',
+  labelSingular: 'Student',
+  namePlural: 'students',
+  nameSingular: 'student',
+  icon: 'IconSchool',
+};

--- a/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/services/dev-seeder-metadata.service.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/dev-seeder/metadata/services/dev-seeder-metadata.service.ts
@@ -14,6 +14,12 @@ import { SURVEY_RESULT_CUSTOM_FIELD_SEEDS } from 'src/engine/workspace-manager/d
 import { PET_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/pet-custom-object-seed.constant';
 import { ROCKET_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/rocket-custom-object-seed.constant';
 import { SURVEY_RESULT_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/survey-results-object-seed.constant';
+import { DEAL_CUSTOM_FIELD_SEEDS } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/deal-custom-field-seeds.constant';
+import { LEAD_CUSTOM_FIELD_SEEDS } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/lead-custom-field-seeds.constant';
+import { STUDENT_CUSTOM_FIELD_SEEDS } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-fields/constants/student-custom-field-seeds.constant';
+import { DEAL_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/deal-custom-object-seed.constant';
+import { LEAD_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/lead-custom-object-seed.constant';
+import { STUDENT_CUSTOM_OBJECT_SEED } from 'src/engine/workspace-manager/dev-seeder/metadata/custom-objects/constants/student-custom-object-seed.constant';
 import { FieldMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/field-metadata-seed.type';
 import { ObjectMetadataSeed } from 'src/engine/workspace-manager/dev-seeder/metadata/types/object-metadata-seed.type';
 
@@ -38,6 +44,12 @@ export class DevSeederMetadataService {
         {
           seed: SURVEY_RESULT_CUSTOM_OBJECT_SEED,
           fields: SURVEY_RESULT_CUSTOM_FIELD_SEEDS,
+        },
+        { seed: LEAD_CUSTOM_OBJECT_SEED, fields: LEAD_CUSTOM_FIELD_SEEDS },
+        { seed: DEAL_CUSTOM_OBJECT_SEED, fields: DEAL_CUSTOM_FIELD_SEEDS },
+        {
+          seed: STUDENT_CUSTOM_OBJECT_SEED,
+          fields: STUDENT_CUSTOM_FIELD_SEEDS,
         },
       ],
       fields: [


### PR DESCRIPTION
## Summary
- create Lead, Deal and Student custom objects
- define sample custom fields for those objects
- register new objects in the dev seeder

## Testing
- `npx nx lint twenty-server --fix`
- `npx nx test twenty-server --runInBand --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_687f3925c258832a871cbdca2e95ef8c